### PR TITLE
Migrate to FastAPI

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { useTheme } from "@mui/material";
 import { AppBar, Toolbar } from "@mui/material";
-import { IssueResponse } from "../models/Issue";
+import { Issue } from "../models/Issue";
 import "./Header.css";
 import IssuesContext from "../context/IssueContext";
 import { useLocation, useNavigate } from "react-router-dom";

--- a/src/components/IssueListItem.tsx
+++ b/src/components/IssueListItem.tsx
@@ -29,14 +29,14 @@ const IssueListItem = ({ issue }: Props) => {
           variant="contained"
           color={statusColor}
           size="large"
-          onClick={() => setStatus(issue._id, toggleStatus(issue.status))}
+          onClick={() => setStatus(issue.id, toggleStatus(issue.status))}
         >
           {issue.status}
         </Button>
 
         <Button
           className="delete-issue"
-          onClick={() => deleteIssue(issue._id)}
+          onClick={() => deleteIssue(issue.id)}
           variant="outlined"
           endIcon={<DeleteIcon />}
           size="small"
@@ -48,7 +48,7 @@ const IssueListItem = ({ issue }: Props) => {
 
       <CardActionArea
         className="issue-description"
-        onClick={() => navigate(`/issue/${issue._id}`)}
+        onClick={() => navigate(`/issue/${issue.id}`)}
       >
         <h3 className="title">Description</h3>
         <p className="issue-description">{issue.description}</p>

--- a/src/components/IssueListItem.tsx
+++ b/src/components/IssueListItem.tsx
@@ -3,11 +3,11 @@ import { Button, Card, CardActionArea } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import DeleteIcon from "@mui/icons-material/Delete";
 import IssuesContext from "../context/IssueContext";
-import { IssueResponse } from "../models/Issue";
+import { Issue } from "../models/Issue";
 import "./IssueListItem.css";
 import { useNavigate } from "react-router-dom";
 interface Props {
-  issue: IssueResponse;
+  issue: Issue;
 }
 
 const IssueListItem = ({ issue }: Props) => {

--- a/src/components/IssuesList.tsx
+++ b/src/components/IssuesList.tsx
@@ -18,7 +18,7 @@ function IssueList({ issues, assigneeFilter, statusFilter }: Props) {
         if (statusFilter !== "" && statusFilter !== issue.status) {
           return;
         }
-        return <IssueListItem key={issue._id} issue={issue} />;
+        return <IssueListItem key={issue.id} issue={issue} />;
       })}
     </ol>
   );

--- a/src/components/IssuesList.tsx
+++ b/src/components/IssuesList.tsx
@@ -1,9 +1,9 @@
-import { IssueResponse } from "../models/Issue";
+import { Issue } from "../models/Issue";
 import IssueListItem from "./IssueListItem";
 import "./IssuesList.css";
 
 interface Props {
-  issues: IssueResponse[];
+  issues: Issue[];
   assigneeFilter: string;
   statusFilter: string;
 }

--- a/src/components/issue-details.tsx
+++ b/src/components/issue-details.tsx
@@ -1,16 +1,15 @@
 import { FormEvent, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { IssueMetadata } from "../models/Issue";
 import { getIssue } from "../services/IssueService";
 import "./IssueDetails.css";
 import IssuesContext from "../context/IssueContext";
 
 // TODO: this needs to use it's own components, not steal from the issuelistitem
 const IssueDetails = () => {
-  const issueId = useParams().id;
+  const issueId = parseInt(useParams().id!);
   const { issues, deleteIssue, setAssignee, setStatus } =
     useContext(IssuesContext);
-  let issue = issues[issues.findIndex((issue) => issue._id === issueId)];
+  let issue = issues[issues.findIndex((issue) => issue.id === issueId)];
   const statusClass =
     issue.status === "closed" ? "issue-status closed" : "issue-status open";
   const [newAssignee, setNewAssignee] = useState("");
@@ -18,9 +17,9 @@ const IssueDetails = () => {
   const applyChanges = (submitEvent: FormEvent) => {
     submitEvent.preventDefault();
     if (newAssignee !== "") {
-      setAssignee(issue._id, newAssignee);
+      setAssignee(issue.id, newAssignee);
     }
-    issue = issues[issues.findIndex((issue) => issue._id === issueId)];
+    issue = issues[issues.findIndex((issue) => issue.id === issueId)];
   };
   const toggleStatus = (currentStatus: string): "open" | "closed" => {
     return currentStatus === "closed" ? "open" : "closed";
@@ -30,11 +29,11 @@ const IssueDetails = () => {
       <section className="issue-header">
         <p
           className={statusClass}
-          onClick={() => setStatus(issue._id, toggleStatus(issue.status))}
+          onClick={() => setStatus(issue.id, toggleStatus(issue.status))}
         >
           {issue.status}
         </p>
-        <button className="delete-issue" onClick={() => deleteIssue(issue._id)}>
+        <button className="delete-issue" onClick={() => deleteIssue(issue.id)}>
           Remove Issue
         </button>
       </section>

--- a/src/context/IssueContext.ts
+++ b/src/context/IssueContext.ts
@@ -1,9 +1,9 @@
 import { createContext } from "react";
-import Issue, { IssueResponse } from "../models/Issue";
+import IssuePrototype, { Issue } from "../models/Issue";
 
 interface IssueContextModel {
-  issues: IssueResponse[];
-  addIssue: (newIssue: Issue) => void;
+  issues: Issue[];
+  addIssue: (newIssue: IssuePrototype) => void;
   deleteIssue: (issueId: string) => void;
   hasAssignee: (id: string, assignee: string) => boolean;
   isOpen: (id: string) => boolean;

--- a/src/context/IssueContext.ts
+++ b/src/context/IssueContext.ts
@@ -1,14 +1,14 @@
 import { createContext } from "react";
-import IssuePrototype, { Issue } from "../models/Issue";
+import { Issue, IssueStatus, IssuePrototype } from "../models/Issue";
 
 interface IssueContextModel {
   issues: Issue[];
   addIssue: (newIssue: IssuePrototype) => void;
-  deleteIssue: (issueId: string) => void;
-  hasAssignee: (id: string, assignee: string) => boolean;
-  isOpen: (id: string) => boolean;
-  setStatus: (id: string, status: "open" | "closed") => void;
-  setAssignee: (id: string, assignee: string) => void;
+  deleteIssue: (issueId: number) => void;
+  hasAssignee: (id: number, assignee: string) => boolean;
+  isOpen: (id: number) => boolean;
+  setStatus: (id: number, status: IssueStatus) => void;
+  setAssignee: (id: number, assignee: string) => void;
 }
 
 const defaults: IssueContextModel = {

--- a/src/context/IssueContextProvider.tsx
+++ b/src/context/IssueContextProvider.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useState } from "react";
-import Issue, { IssueResponse } from "../models/Issue";
+import IssuePrototype, { Issue } from "../models/Issue";
 import {
   addIssueToDb,
   deleteIssueFromDb,
@@ -18,7 +18,7 @@ const IssuesContextProvider = ({ children }: Props) => {
   // break encapsulation, but we need to update it based on filters and original getAll
 
   // we can add useEffect here to set initial getAll values
-  const [issues, setIssues] = useState<IssueResponse[]>([]);
+  const [issues, setIssues] = useState<Issue[]>([]);
   const getIssues = () => {
     getAllIssues().then((res) => {
       setIssues(res);
@@ -33,7 +33,7 @@ const IssuesContextProvider = ({ children }: Props) => {
     getIssues();
   }, []);
 
-  const addIssue = (newIssue: Issue) => {
+  const addIssue = (newIssue: IssuePrototype) => {
     addIssueToDb(newIssue).then(
       (res) => {
         console.info("ADDED TO DB", res._id);

--- a/src/context/IssueContextProvider.tsx
+++ b/src/context/IssueContextProvider.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from "react";
-import IssuePrototype, { Issue } from "../models/Issue";
+import { Issue, IssuePrototype, IssueStatus } from "../models/Issue";
 import {
-  addIssueToDb,
+  createIssue,
   deleteIssueFromDb,
   getAllIssues,
   updateIssueInDb,
@@ -34,10 +34,10 @@ const IssuesContextProvider = ({ children }: Props) => {
   }, []);
 
   const addIssue = (newIssue: IssuePrototype) => {
-    addIssueToDb(newIssue).then(
+    createIssue(newIssue).then(
       (res) => {
-        console.info("ADDED TO DB", res._id);
-        setIssues([...issues, res]);
+        console.info("ADDED TO DB", res.id);
+        setIssues([res, ...issues]);
       },
       (err) => {
         console.error("UNABLE TO ADD TO DB", err);
@@ -45,12 +45,12 @@ const IssuesContextProvider = ({ children }: Props) => {
     );
   };
 
-  const deleteIssue = (issueId: string) => {
+  const deleteIssue = (issueId: number) => {
     deleteIssueFromDb(issueId).then(
       (res) => {
         console.info("DELETED FROM DB", res);
         setIssues((prev) => {
-          const index: number = prev.findIndex((item) => item._id === issueId);
+          const index: number = prev.findIndex((item) => item.id === issueId);
           return [...prev.slice(0, index), ...prev.slice(index + 1)];
         });
       },
@@ -60,34 +60,41 @@ const IssuesContextProvider = ({ children }: Props) => {
     );
   };
 
-  const hasAssignee = (id: string, assignee: string): boolean => {
+  const hasAssignee = (id: number, assignee: string): boolean => {
     const rightAssigneeIds = issues.map((issue) => {
       if (issue.assignee === assignee) {
-        return issue._id;
+        return issue.id;
       }
     });
     console.info("ids with this assignee: ", rightAssigneeIds);
     return rightAssigneeIds.includes(id);
   };
 
-  const isOpen = (id: string) => {
+  const isOpen = (id: number) => {
     const openIds = issues.map((issue) => {
       if (issue.status === "open") {
-        return issue._id;
+        return issue.id;
       }
     });
     console.info("open ids", openIds);
     return openIds.includes(id);
   };
 
-  const setStatus = (id: string, status: "open" | "closed") => {
-    updateIssueInDb(id, undefined, status).then(
+  const setStatus = (id: number, status: IssueStatus) => {
+    const currentIssueIdx = issues.findIndex((x) => x.id === id);
+    const targetIssueData = issues[currentIssueIdx];
+    targetIssueData.status = status;
+
+    updateIssueInDb(id, targetIssueData).then(
       (res) => {
         // need to change the issue in state to be the updated v from response
         setIssues((prev) => {
-          const index: number = prev.findIndex((item) => item._id === id);
           // should put the returned updated issue in the same place as the prev
-          return [...prev.slice(0, index), res, ...prev.slice(index + 1)];
+          return [
+            ...prev.slice(0, currentIssueIdx),
+            res,
+            ...prev.slice(currentIssueIdx + 1),
+          ];
         });
       },
       (err) => {
@@ -96,14 +103,21 @@ const IssuesContextProvider = ({ children }: Props) => {
     );
   };
 
-  const setAssignee = (id: string, assignee: string) => {
-    updateIssueInDb(id, assignee, undefined).then(
+  const setAssignee = (id: number, assignee: string) => {
+    const currentIssueIdx = issues.findIndex((x) => x.id === id);
+    const targetIssueData = issues[currentIssueIdx];
+    targetIssueData.assignee = assignee;
+
+    updateIssueInDb(id, targetIssueData).then(
       (res) => {
         // need to change the issue in state to be the updated v from response
         setIssues((prev) => {
-          const index: number = prev.findIndex((item) => item._id === id);
           // should put the returned updated issue in the same place as the prev
-          return [...prev.slice(0, index), res, ...prev.slice(index + 1)];
+          return [
+            ...prev.slice(0, currentIssueIdx),
+            res,
+            ...prev.slice(currentIssueIdx + 1),
+          ];
         });
       },
       (err) => {

--- a/src/context/IssueContextProvider.tsx
+++ b/src/context/IssueContextProvider.tsx
@@ -107,6 +107,7 @@ const IssuesContextProvider = ({ children }: Props) => {
     const currentIssueIdx = issues.findIndex((x) => x.id === id);
     const targetIssueData = issues[currentIssueIdx];
     targetIssueData.assignee = assignee;
+    //
 
     updateIssueInDb(id, targetIssueData).then(
       (res) => {

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -1,27 +1,21 @@
-// I would prefer to use the terse syntax 'Issue' most often.
-// maybe we change this again to be IssuePrototype (no ID) and Issue (has id)
+export type IssueStatus = "open" | "closed";
 
-export default interface Issue {
+export interface IssuePrototype {
+  title?: string;
   description: string;
-  status: "open" | "closed" | string; // consider custom typing or something to only allow open or closed
+  status: IssueStatus;
   assignee: string;
 }
 
-export interface IssueResponse extends Issue {
-  _id: string;
+export interface Issue extends IssuePrototype {
+  id: number;
 }
 
-export interface IssueMetadata extends IssueResponse {
-  _created: string;
-  _changed: string;
-  _createdby: string; // consider finding the specific datettime format type
-  _changedby: string;
-  _keywords: string[];
-  _version: number;
-}
-
+/**
+ * represents the keys which can be used to filter the issues presented on the home page
+ */
 export interface IssueFilter {
   description?: string;
-  status?: string; // for now, will be actual type in next version
+  status?: IssueStatus;
   assignee?: string;
 }

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
-import Issue, { IssueMetadata, IssueResponse } from "../models/Issue";
+import IssuePrototype, { IssueMetadata, Issue } from "../models/Issue";
 
 const dbApiKey = process.env.REACT_APP_DB_API_KEY_DEV || "";
 const issuesDocumentUrl = "https://issuetracker-b807.restdb.io/rest/issue";
 
-export const getAllIssues = (): Promise<IssueResponse[]> => {
+export const getAllIssues = (): Promise<Issue[]> => {
   return axios
     .get(issuesDocumentUrl, {
       headers: {
@@ -24,7 +24,7 @@ export const getIssue = (id: string): Promise<IssueMetadata> => {
     .then((res) => res.data);
 };
 
-export const addIssueToDb = (newIssue: Issue): Promise<IssueResponse> => {
+export const addIssueToDb = (newIssue: IssuePrototype): Promise<Issue> => {
   return axios({
     method: "post",
     url: issuesDocumentUrl,
@@ -49,7 +49,7 @@ export const updateIssueInDb = (
   id: string,
   assignee?: string,
   status?: "open" | "closed"
-): Promise<IssueResponse> => {
+): Promise<Issue> => {
   let fieldsToUpdate = {};
 
   // there is surely a more concise version of this logic

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -1,75 +1,59 @@
 import axios from "axios";
-import IssuePrototype, { IssueMetadata, Issue } from "../models/Issue";
+import { IssuePrototype, Issue, IssueStatus } from "../models/Issue";
 
-const dbApiKey = process.env.REACT_APP_DB_API_KEY_DEV || "";
-const issuesDocumentUrl = "https://issuetracker-b807.restdb.io/rest/issue";
+const backendDevURL = "http://0.0.0.0:8000";
 
-export const getAllIssues = (): Promise<Issue[]> => {
+export const getAllIssues = (
+  offset?: number,
+  limit?: number
+): Promise<Issue[]> => {
   return axios
-    .get(issuesDocumentUrl, {
-      headers: {
-        "x-api-key": dbApiKey,
+    .get(`${backendDevURL}/issues/`, {
+      params: {
+        offset: offset,
+        limit: limit,
       },
     })
     .then((res) => res.data);
 };
 
-export const getIssue = (id: string): Promise<IssueMetadata> => {
+export const getIssue = (id: number, all_details?: boolean): Promise<Issue> => {
   return axios
-    .get(`${issuesDocumentUrl}/${id} `, {
-      headers: {
-        "x-api-key": dbApiKey,
+    .get(`${backendDevURL}/issues/${id}`, {
+      params: {
+        all_details: all_details,
       },
     })
     .then((res) => res.data);
 };
 
-export const addIssueToDb = (newIssue: IssuePrototype): Promise<Issue> => {
+export const createIssue = (newIssue: IssuePrototype): Promise<Issue> => {
   return axios({
     method: "post",
-    url: issuesDocumentUrl,
+    url: `${backendDevURL}/issues`,
     data: {
+      title: newIssue.title || "",
       assignee: newIssue.assignee,
       description: newIssue.description,
       status: newIssue.status,
     },
-    headers: { "x-api-key": dbApiKey },
   }).then((res) => res.data);
 };
 
-export const deleteIssueFromDb = (id: string): Promise<string> => {
+export const deleteIssueFromDb = (id: number): Promise<Issue> => {
   return axios({
     method: "delete",
-    url: `${issuesDocumentUrl}/${id}`,
-    headers: { "x-api-key": dbApiKey },
+    url: `${backendDevURL}/issues/${id}`,
   }).then((res) => res.data);
 };
 
 export const updateIssueInDb = (
-  id: string,
-  assignee?: string,
-  status?: "open" | "closed"
+  id: number,
+  newIssue: IssuePrototype
 ): Promise<Issue> => {
-  let fieldsToUpdate = {};
-
-  // there is surely a more concise version of this logic
-  if (assignee && status) {
-    fieldsToUpdate = {
-      status: status,
-      assignee: assignee,
-    };
-  } else if (assignee) {
-    fieldsToUpdate = { assignee: assignee };
-  } else if (status) {
-    fieldsToUpdate = { status: status };
-  } else {
-    console.warn("no issue properties provided to update fxn!");
-  }
-  console.info("UPDATE BODY: ", fieldsToUpdate);
   return axios({
     method: "put",
-    url: `${issuesDocumentUrl}/${id}`,
-    headers: { "x-api-key": dbApiKey },
-    data: fieldsToUpdate,
+    url: `${backendDevURL}/issues/${id}`,
+    data: newIssue,
   }).then((res) => res.data);
 };

--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { IssuePrototype, Issue, IssueStatus } from "../models/Issue";
+import { IssuePrototype, Issue } from "../models/Issue";
 
 const backendDevURL = "http://0.0.0.0:8000";
 


### PR DESCRIPTION
# Summary
Remove dependency on RestDB.io in favor of FastAPI. The new server is developed and owned by me and offers swifter response times. Closes #22 

## Changes
### Issue (models)
- Include true `type` for IssueStatus allowing only 'open' and 'closed'
- Refactor such that `Issue` refers to the model including an ID, since this was most commonly used.
  - 'IssueResponse extends Issue' --> 'Issue extends IssuePrototype'
- Remove IssueMetadata model
- Issue.id is now of type `number`

### IssueService
- Service calls now hit a 'dev' localhost endpoint which points to the backend
- Service calls have adjusted parameters, notably that 'update' requires an IssuePrototype object instead of individual parameters.
### Context
- Update context methods to conform to the new service parameter requirements
### Components
- Replace deprecated references to '_id'